### PR TITLE
Fix bug in Trie#isMember

### DIFF
--- a/Data Structures/Trie.js
+++ b/Data Structures/Trie.js
@@ -73,7 +73,7 @@
     trie.add('Helper');
     trie.add('Helped');
     
-    trie.isMember('Hexagon');    // false
+    trie.isMember('Hexagon');// false
     trie.isMember('Helpe');  // false
     trie.isMember('Helper'); // true
     trie.isMember('Help');   // true

--- a/Data Structures/Trie.js
+++ b/Data Structures/Trie.js
@@ -37,8 +37,10 @@
             var current = this.root;
             
             // walkthrough to the last letter in for the searched word
-            for (var i = 0, len = word.length; i < len; i++) {
+            var i = 0;
+            while (current && i < word.length) {
                 current = current[word[i]];
+                i += 1;
             }
             
             // last letter in the word exists in the trie, and is marked as an end of word
@@ -65,13 +67,13 @@
         
     };
     
-    trie = new Trie();
+    var trie = new Trie();
     trie.add('Hello');
     trie.add('Help');
     trie.add('Helper');
     trie.add('Helped');
     
-    trie.isMember('Hex');    // false
+    trie.isMember('Hexagon');    // false
     trie.isMember('Helpe');  // false
     trie.isMember('Helper'); // true
     trie.isMember('Help');   // true


### PR DESCRIPTION
If there was more than one unfound char in word, for loop would throw TypeError. Changed it to a while loop that confirms existance of current.